### PR TITLE
Applied Deodand's FOC Low Speed Brake Locking Fix

### DIFF
--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -1732,7 +1732,8 @@ void mcpwm_foc_adc_int_handler(void *p, uint32_t flags) {
 		// to get as smooth braking as possible.
 		if (m_control_mode == CONTROL_MODE_CURRENT_BRAKE
 				//				&& (m_conf->foc_sensor_mode != FOC_SENSOR_MODE_ENCODER) // Don't use this with encoders
-				&& fabsf(duty_filtered) < 0.03) {
+				&& fabsf(duty_filtered)*GET_INPUT_VOLTAGE() < 0.5
+        			&& (fmax( m_iq_set , 0.5/m_conf->foc_motor_r ) >  (double) fabsf(m_motor_state.iq_filter))) {
 			control_duty = true;
 			duty_set = 0.0;
 		}


### PR DESCRIPTION
https://www.electric-skateboard.builders/t/need-a-few-testers-with-focbox-unity-builds-low-speed-braking-fix-needs-testing/80201

No rebuild_all errors, loaded the outputed 410, 411, 412 VESC_default.bin via your ESC_Tool 3.102 > Firmware > Custom File to my dual focbox build. 

Completely fixes the brakes locking up at low speed when running FOC mode for me, tested on Dual (standard) focboxes, although leaves a mild cogging sound at the very end instead of locking up completely.